### PR TITLE
Replaced AsyncMqttClient with PubSubClient

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ lib_deps =
     ArduinoJson@>=6.15.2
     luc-github/ESP32SSDP
     IRremoteESP8266@>=2.7.10
-	marvinroger/AsyncMqttClient@>=0.8.2
+	PubSubClient@>=2.8
     earlephilhower/ESP8266Audio
     earlephilhower/ESP8266SAM
     nailbuster/ESP8266FtpServer

--- a/src/app/kodi_remote/kodi_remote_app_main.cpp
+++ b/src/app/kodi_remote/kodi_remote_app_main.cpp
@@ -520,7 +520,7 @@ int kodi_remote_publish(const char* method, const char* params, SpiRamJsonDocume
     publish_client.setAuthorization( kodi_remote_config->user, kodi_remote_config->pass );
     httpcode = publish_client.POST((uint8_t*)payload, strlen(payload));
 
-    if (doc != NULL && doc != nullptr) {
+    if (httpcode > 200 && httpcode < 300 && doc != NULL && doc != nullptr) {
         DeserializationError error = deserializeJson( *(doc), publish_client.getStream() );
         if (error) {
             log_e("kodi_remote deserializeJson() failed: %s", error.c_str() );

--- a/src/app/mqtt_control/mqtt_control_app_main.cpp
+++ b/src/app/mqtt_control/mqtt_control_app_main.cpp
@@ -89,7 +89,7 @@ void mqtt_control_main_setup( uint32_t tile_num ) {
 
     mqtt_control_page_setup();
 
-    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECTED | MQTTCTL_DISCONNECTED , mqtt_control_mqtt_event_cb, "mqtt control" );
+    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECT | MQTTCTL_DISCONNECT , mqtt_control_mqtt_event_cb, "mqtt control" );
     mqtt_register_message_cb( mqtt_control_message_cb );
 }
 
@@ -220,16 +220,16 @@ void mqtt_control_page_clean() {
 
 static bool mqtt_control_mqtt_event_cb( EventBits_t event, void *arg ) {
     switch( event ) {
-        case MQTTCTL_OFF:          mqtt_control_state = false;
-                                   mqtt_control_app_hide_indicator();
-                                   break;
-        case MQTTCTL_CONNECTED:    mqtt_control_state = true;
-                                   mqtt_control_app_set_indicator( ICON_INDICATOR_OK );
-                                   mqtt_control_page_refresh();
-                                   break;
-        case MQTTCTL_DISCONNECTED: mqtt_control_state = false;
-                                   mqtt_control_app_set_indicator( ICON_INDICATOR_FAIL );
-                                   break;
+        case MQTTCTL_OFF:        mqtt_control_state = false;
+                                 mqtt_control_app_hide_indicator();
+                                 break;
+        case MQTTCTL_CONNECT:    mqtt_control_state = true;
+                                 mqtt_control_app_set_indicator( ICON_INDICATOR_OK );
+                                 mqtt_control_page_refresh();
+                                 break;
+        case MQTTCTL_DISCONNECT: mqtt_control_state = false;
+                                 mqtt_control_app_set_indicator( ICON_INDICATOR_FAIL );
+                                 break;
     }
     return( true );
 }

--- a/src/app/mqtt_control/mqtt_control_app_main.cpp
+++ b/src/app/mqtt_control/mqtt_control_app_main.cpp
@@ -50,7 +50,7 @@ LV_FONT_DECLARE(Ubuntu_12px);
 
 static void exit_mqtt_control_main_event_cb( lv_obj_t * obj, lv_event_t event );
 static bool mqtt_control_mqtt_event_cb( EventBits_t event, void *arg );
-static void mqtt_control_message_cb(char *topic, char *payload, size_t length);
+static void mqtt_control_message_cb(char *topic, byte *payload, size_t length);
 static void mqtt_control_button_event_cb( lv_obj_t * obj, lv_event_t event );
 static void mqtt_control_switch_event_cb( lv_obj_t * obj, lv_event_t event );
 static void mqtt_control_item_cb( lv_obj_t * obj, lv_event_t event );
@@ -89,7 +89,7 @@ void mqtt_control_main_setup( uint32_t tile_num ) {
 
     mqtt_control_page_setup();
 
-    mqtt_register_cb( MQTT_OFF | MQTT_CONNECTED | MQTT_DISCONNECTED , mqtt_control_mqtt_event_cb, "mqtt control" );
+    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECTED | MQTTCTL_DISCONNECTED , mqtt_control_mqtt_event_cb, "mqtt control" );
     mqtt_register_message_cb( mqtt_control_message_cb );
 }
 
@@ -220,21 +220,21 @@ void mqtt_control_page_clean() {
 
 static bool mqtt_control_mqtt_event_cb( EventBits_t event, void *arg ) {
     switch( event ) {
-        case MQTT_OFF:          mqtt_control_state = false;
-                                mqtt_control_app_hide_indicator();
-                                break;
-        case MQTT_CONNECTED:    mqtt_control_state = true;
-                                mqtt_control_app_set_indicator( ICON_INDICATOR_OK );
-                                mqtt_control_page_refresh();
-                                break;
-        case MQTT_DISCONNECTED: mqtt_control_state = false;
-                                mqtt_control_app_set_indicator( ICON_INDICATOR_FAIL );
-                                break;
+        case MQTTCTL_OFF:          mqtt_control_state = false;
+                                   mqtt_control_app_hide_indicator();
+                                   break;
+        case MQTTCTL_CONNECTED:    mqtt_control_state = true;
+                                   mqtt_control_app_set_indicator( ICON_INDICATOR_OK );
+                                   mqtt_control_page_refresh();
+                                   break;
+        case MQTTCTL_DISCONNECTED: mqtt_control_state = false;
+                                   mqtt_control_app_set_indicator( ICON_INDICATOR_FAIL );
+                                   break;
     }
     return( true );
 }
 
-static void mqtt_control_message_cb(char *topic, char *payload, size_t length) {
+static void mqtt_control_message_cb(char *topic, byte *payload, size_t length) {
     if (!mqtt_control_state) return;
     if (!length) return;
     

--- a/src/app/mqtt_player/mqtt_player_app_main.cpp
+++ b/src/app/mqtt_player/mqtt_player_app_main.cpp
@@ -69,7 +69,7 @@ static void mqtt_player_play_event_cb( lv_obj_t * obj, lv_event_t event );
 static void mqtt_player_next_event_cb( lv_obj_t * obj, lv_event_t event );
 static void mqtt_player_prev_event_cb( lv_obj_t * obj, lv_event_t event );
 static bool mqtt_player_mqtt_event_cb( EventBits_t event, void *arg );
-static void mqtt_player_message_cb(char *topic, char *payload, size_t length);
+static void mqtt_player_message_cb(char *topic, byte *payload, size_t length);
 void mqtt_player_task( lv_task_t * task );
 
 void mqtt_player_main_setup( uint32_t tile_num ) {
@@ -119,7 +119,7 @@ void mqtt_player_main_setup( uint32_t tile_num ) {
     lv_obj_t *mqtt_player_volume_up = wf_add_image_button( mqtt_player_main_tile, up_32px, mqtt_player_volume_up_event_cb, &mqtt_player_main_style );
     lv_obj_align( mqtt_player_volume_up, mqtt_player_speaker, LV_ALIGN_OUT_RIGHT_MID, 32, 0 );
 
-    mqtt_register_cb( MQTT_OFF | MQTT_CONNECTED | MQTT_DISCONNECTED , mqtt_player_mqtt_event_cb, "mqtt player" );
+    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECTED | MQTTCTL_DISCONNECTED , mqtt_player_mqtt_event_cb, "mqtt player" );
     mqtt_register_message_cb( mqtt_player_message_cb );
 
     // create an task that runs every second
@@ -128,28 +128,28 @@ void mqtt_player_main_setup( uint32_t tile_num ) {
 
 static bool mqtt_player_mqtt_event_cb( EventBits_t event, void *arg ) {
     switch( event ) {
-        case MQTT_OFF:          mqtt_player_state = false;
-                                mqtt_player_app_hide_indicator();
-                                break;
-        case MQTT_CONNECTED:    mqtt_player_state = true;
-                                {
-                                    char mqtt_player_subscribe_topic[34];
-                                    mqtt_player_config_t *mqtt_player_config = mqtt_player_get_config();
-                                    snprintf( mqtt_player_subscribe_topic, sizeof( mqtt_player_subscribe_topic ), "%s/#", mqtt_player_config->topic_base );
-                                    mqtt_subscribe( mqtt_player_subscribe_topic );
-                                }
-                                mqtt_player_app_set_indicator( ICON_INDICATOR_OK );
-                                break;
-        case MQTT_DISCONNECTED: mqtt_player_state = false;
-                                mqtt_player_app_set_indicator( ICON_INDICATOR_FAIL );
-                                lv_label_set_text( mqtt_player_artist, "" );
-                                lv_label_set_text( mqtt_player_title, "" );
-                                break;
+        case MQTTCTL_OFF:          mqtt_player_state = false;
+                                   mqtt_player_app_hide_indicator();
+                                   break;
+        case MQTTCTL_CONNECTED:    mqtt_player_state = true;
+                                   {
+                                       char mqtt_player_subscribe_topic[34];
+                                       mqtt_player_config_t *mqtt_player_config = mqtt_player_get_config();
+                                       snprintf( mqtt_player_subscribe_topic, sizeof( mqtt_player_subscribe_topic ), "%s/#", mqtt_player_config->topic_base );
+                                       mqtt_subscribe( mqtt_player_subscribe_topic );
+                                   }
+                                   mqtt_player_app_set_indicator( ICON_INDICATOR_OK );
+                                   break;
+        case MQTTCTL_DISCONNECTED: mqtt_player_state = false;
+                                   mqtt_player_app_set_indicator( ICON_INDICATOR_FAIL );
+                                   lv_label_set_text( mqtt_player_artist, "" );
+                                   lv_label_set_text( mqtt_player_title, "" );
+                                   break;
     }
     return( true );
 }
 
-static void mqtt_player_message_cb(char *topic, char *payload, size_t length) {
+static void mqtt_player_message_cb(char *topic, byte *payload, size_t length) {
     if (!length) return;
 
     mqtt_player_config_t *mqtt_player_config = mqtt_player_get_config();

--- a/src/app/mqtt_player/mqtt_player_app_main.cpp
+++ b/src/app/mqtt_player/mqtt_player_app_main.cpp
@@ -119,7 +119,7 @@ void mqtt_player_main_setup( uint32_t tile_num ) {
     lv_obj_t *mqtt_player_volume_up = wf_add_image_button( mqtt_player_main_tile, up_32px, mqtt_player_volume_up_event_cb, &mqtt_player_main_style );
     lv_obj_align( mqtt_player_volume_up, mqtt_player_speaker, LV_ALIGN_OUT_RIGHT_MID, 32, 0 );
 
-    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECTED | MQTTCTL_DISCONNECTED , mqtt_player_mqtt_event_cb, "mqtt player" );
+    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECT | MQTTCTL_DISCONNECT , mqtt_player_mqtt_event_cb, "mqtt player" );
     mqtt_register_message_cb( mqtt_player_message_cb );
 
     // create an task that runs every second
@@ -128,23 +128,23 @@ void mqtt_player_main_setup( uint32_t tile_num ) {
 
 static bool mqtt_player_mqtt_event_cb( EventBits_t event, void *arg ) {
     switch( event ) {
-        case MQTTCTL_OFF:          mqtt_player_state = false;
-                                   mqtt_player_app_hide_indicator();
-                                   break;
-        case MQTTCTL_CONNECTED:    mqtt_player_state = true;
-                                   {
-                                       char mqtt_player_subscribe_topic[34];
-                                       mqtt_player_config_t *mqtt_player_config = mqtt_player_get_config();
-                                       snprintf( mqtt_player_subscribe_topic, sizeof( mqtt_player_subscribe_topic ), "%s/#", mqtt_player_config->topic_base );
-                                       mqtt_subscribe( mqtt_player_subscribe_topic );
-                                   }
-                                   mqtt_player_app_set_indicator( ICON_INDICATOR_OK );
-                                   break;
-        case MQTTCTL_DISCONNECTED: mqtt_player_state = false;
-                                   mqtt_player_app_set_indicator( ICON_INDICATOR_FAIL );
-                                   lv_label_set_text( mqtt_player_artist, "" );
-                                   lv_label_set_text( mqtt_player_title, "" );
-                                   break;
+        case MQTTCTL_OFF:        mqtt_player_state = false;
+                                 mqtt_player_app_hide_indicator();
+                                 break;
+        case MQTTCTL_CONNECT:    mqtt_player_state = true;
+                                 {
+                                     char mqtt_player_subscribe_topic[34];
+                                     mqtt_player_config_t *mqtt_player_config = mqtt_player_get_config();
+                                     snprintf( mqtt_player_subscribe_topic, sizeof( mqtt_player_subscribe_topic ), "%s/#", mqtt_player_config->topic_base );
+                                     mqtt_subscribe( mqtt_player_subscribe_topic );
+                                 }
+                                 mqtt_player_app_set_indicator( ICON_INDICATOR_OK );
+                                 break;
+        case MQTTCTL_DISCONNECT: mqtt_player_state = false;
+                                 mqtt_player_app_set_indicator( ICON_INDICATOR_FAIL );
+                                 lv_label_set_text( mqtt_player_artist, "" );
+                                 lv_label_set_text( mqtt_player_title, "" );
+                                 break;
     }
     return( true );
 }

--- a/src/app/powermeter/powermeter_main.cpp
+++ b/src/app/powermeter/powermeter_main.cpp
@@ -59,7 +59,7 @@ bool powermeter_mqtt_event_cb( EventBits_t event, void *arg );
 static void enter_powermeter_setup_event_cb( lv_obj_t * obj, lv_event_t event );
 void powermeter_main_task( lv_task_t * task );
 
-void callback(char *topic, char *payload, size_t length) {
+void powermeter_message_cb(char *topic, byte *payload, size_t length) {
     if (strncmp(topic, powermeter_get_config()->topic, strlen(powermeter_get_config()->topic) - 1) != 0) return;
 
     char *msg = NULL;
@@ -178,32 +178,32 @@ void powermeter_main_tile_setup( uint32_t tile_num ) {
     lv_label_set_text( power_label, "n/a" );
     lv_obj_align( power_label, power_cont, LV_ALIGN_IN_RIGHT_MID, -5, 0 );
 
-    mqtt_register_cb( MQTT_OFF | MQTT_CONNECTED | MQTT_DISCONNECTED , powermeter_mqtt_event_cb, "powermeter" );
-    mqtt_register_message_cb( callback );
+    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECTED | MQTTCTL_DISCONNECTED , powermeter_mqtt_event_cb, "powermeter" );
+    mqtt_register_message_cb( powermeter_message_cb );
 }
 
 bool powermeter_mqtt_event_cb( EventBits_t event, void *arg ) {
     powermeter_config_t *powermeter_config = powermeter_get_config();
     switch( event ) {
-        case MQTT_OFF:          app_hide_indicator( powermeter_get_app_icon() );
-                                widget_hide_indicator( powermeter_get_widget_icon() );
-                                widget_set_label( powermeter_get_widget_icon(), "n/a" );
-                                break;
-        case MQTT_CONNECTED:    if (powermeter_config->autoconnect) {
-                                    mqtt_subscribe( powermeter_config->topic );
-                                    app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_OK );
-                                    widget_set_indicator( powermeter_get_widget_icon(), ICON_INDICATOR_OK );
-                                } else {
-                                    app_hide_indicator( powermeter_get_app_icon() );
-                                    widget_hide_indicator( powermeter_get_widget_icon() );
-                                    widget_set_label( powermeter_get_widget_icon(), "n/a" );
-                                }
-                                break;
-        case MQTT_DISCONNECTED: if (powermeter_config->autoconnect) {
-                                    app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_FAIL );
-                                    widget_set_indicator( powermeter_get_widget_icon() , ICON_INDICATOR_FAIL );
-                                }
-                                break;
+        case MQTTCTL_OFF:          app_hide_indicator( powermeter_get_app_icon() );
+                                   widget_hide_indicator( powermeter_get_widget_icon() );
+                                   widget_set_label( powermeter_get_widget_icon(), "n/a" );
+                                   break;
+        case MQTTCTL_CONNECTED:    if (powermeter_config->autoconnect) {
+                                       mqtt_subscribe( powermeter_config->topic );
+                                       app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_OK );
+                                       widget_set_indicator( powermeter_get_widget_icon(), ICON_INDICATOR_OK );
+                                   } else {
+                                       app_hide_indicator( powermeter_get_app_icon() );
+                                       widget_hide_indicator( powermeter_get_widget_icon() );
+                                       widget_set_label( powermeter_get_widget_icon(), "n/a" );
+                                   }
+                                   break;
+        case MQTTCTL_DISCONNECTED: if (powermeter_config->autoconnect) {
+                                       app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_FAIL );
+                                       widget_set_indicator( powermeter_get_widget_icon() , ICON_INDICATOR_FAIL );
+                                   }
+                                   break;
     }
     return( true );
 }

--- a/src/app/powermeter/powermeter_main.cpp
+++ b/src/app/powermeter/powermeter_main.cpp
@@ -178,32 +178,32 @@ void powermeter_main_tile_setup( uint32_t tile_num ) {
     lv_label_set_text( power_label, "n/a" );
     lv_obj_align( power_label, power_cont, LV_ALIGN_IN_RIGHT_MID, -5, 0 );
 
-    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECTED | MQTTCTL_DISCONNECTED , powermeter_mqtt_event_cb, "powermeter" );
+    mqtt_register_cb( MQTTCTL_OFF | MQTTCTL_CONNECT | MQTTCTL_DISCONNECT , powermeter_mqtt_event_cb, "powermeter" );
     mqtt_register_message_cb( powermeter_message_cb );
 }
 
 bool powermeter_mqtt_event_cb( EventBits_t event, void *arg ) {
     powermeter_config_t *powermeter_config = powermeter_get_config();
     switch( event ) {
-        case MQTTCTL_OFF:          app_hide_indicator( powermeter_get_app_icon() );
-                                   widget_hide_indicator( powermeter_get_widget_icon() );
-                                   widget_set_label( powermeter_get_widget_icon(), "n/a" );
-                                   break;
-        case MQTTCTL_CONNECTED:    if (powermeter_config->autoconnect) {
-                                       mqtt_subscribe( powermeter_config->topic );
-                                       app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_OK );
-                                       widget_set_indicator( powermeter_get_widget_icon(), ICON_INDICATOR_OK );
-                                   } else {
-                                       app_hide_indicator( powermeter_get_app_icon() );
-                                       widget_hide_indicator( powermeter_get_widget_icon() );
-                                       widget_set_label( powermeter_get_widget_icon(), "n/a" );
-                                   }
-                                   break;
-        case MQTTCTL_DISCONNECTED: if (powermeter_config->autoconnect) {
-                                       app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_FAIL );
-                                       widget_set_indicator( powermeter_get_widget_icon() , ICON_INDICATOR_FAIL );
-                                   }
-                                   break;
+        case MQTTCTL_OFF:        app_hide_indicator( powermeter_get_app_icon() );
+                                 widget_hide_indicator( powermeter_get_widget_icon() );
+                                 widget_set_label( powermeter_get_widget_icon(), "n/a" );
+                                 break;
+        case MQTTCTL_CONNECT:    if (powermeter_config->autoconnect) {
+                                     mqtt_subscribe( powermeter_config->topic );
+                                     app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_OK );
+                                     widget_set_indicator( powermeter_get_widget_icon(), ICON_INDICATOR_OK );
+                                 } else {
+                                     app_hide_indicator( powermeter_get_app_icon() );
+                                     widget_hide_indicator( powermeter_get_widget_icon() );
+                                     widget_set_label( powermeter_get_widget_icon(), "n/a" );
+                                 }
+                                 break;
+        case MQTTCTL_DISCONNECT: if (powermeter_config->autoconnect) {
+                                     app_set_indicator( powermeter_get_app_icon(), ICON_INDICATOR_FAIL );
+                                     widget_set_indicator( powermeter_get_widget_icon() , ICON_INDICATOR_FAIL );
+                                 }
+                                 break;
     }
     return( true );
 }

--- a/src/utils/mqtt/mqtt.cpp
+++ b/src/utils/mqtt/mqtt.cpp
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 #include <Arduino.h>
-#include <AsyncMqttClient.h>
+#include <PubSubClient.h>
+#include <WiFi.h>
 
 #include "config.h"
 #include "utils/mqtt/mqtt.h"
@@ -29,12 +30,14 @@
 bool mqtt_setup = false;
 bool mqtt_run = false;
 bool mqtt_needs_publish = false;
+bool mqtt_connected = false;
 EventGroupHandle_t mqtt_status = NULL;
 portMUX_TYPE DRAM_ATTR mqttMux = portMUX_INITIALIZER_UNLOCKED;
 callback_t *mqtt_callback = NULL;
 lv_task_t * _mqtt_main_task;
 
-AsyncMqttClient mqtt_client;
+WiFiClient espClient;
+PubSubClient mqtt_client( espClient );
 char clientId[24];
 
 bool mqtt_send_event_cb( EventBits_t event, void *arg );
@@ -43,34 +46,40 @@ bool mqtt_get_event( EventBits_t bits );
 void mqtt_clear_event( EventBits_t bits );
 std::vector<MqttMessageCallback> _mqtt_message_callbacks;
 
-void _mqtt_connected(bool sessionPresent) {
+void _mqtt_connected() {
   log_d("mqtt connected");
+  mqtt_connected = true;
 
   mqtt_publish_state();
   mqtt_needs_publish = true;
 
-  mqtt_set_event( MQTT_CONNECT );
-  mqtt_clear_event( MQTT_DISCONNECT | MQTT_DISCONNECTED | MQTT_OFF );
-  mqtt_send_event_cb( MQTT_CONNECT, (void *)sessionPresent );
+  mqtt_set_event( MQTTCTL_CONNECT );
+  mqtt_clear_event( MQTTCTL_DISCONNECT | MQTTCTL_DISCONNECTED | MQTTCTL_OFF );
+  mqtt_send_event_cb( MQTTCTL_CONNECT, (void *)NULL );
 }
 
-void _mqtt_disconnected(AsyncMqttClientDisconnectReason reason) {
-  log_d("mqtt disconnected, because %d", reason);
+void _mqtt_disconnected() {
+  log_d("mqtt disconnected");
+  mqtt_connected = false;
 
-  mqtt_set_event( MQTT_DISCONNECT );
-  mqtt_clear_event( MQTT_CONNECT | MQTT_CONNECTED | MQTT_OFF );
-  mqtt_send_event_cb( MQTT_DISCONNECT, (void *)reason );
+  mqtt_set_event( MQTTCTL_DISCONNECT );
+  mqtt_clear_event( MQTTCTL_CONNECT | MQTTCTL_CONNECTED | MQTTCTL_OFF );
+  mqtt_send_event_cb( MQTTCTL_DISCONNECT, (void *)NULL );
 }
 
-void _mqtt_subscribe(uint16_t packetId, uint8_t qos) {
-  log_d("mqtt subscribe, package %d", packetId);
+void _mqtt_connection() {
+  bool connected = mqtt_client.connected();
+
+  if (!mqtt_connected && connected){
+    _mqtt_connected();
+  }
+  
+  if (mqtt_connected && !connected){
+    _mqtt_disconnected();
+  }
 }
 
-void _mqtt_unsubscribe(uint16_t packetId) {
-  log_d("mqtt unsubscribe, package %d", packetId);
-}
-
-void _mqtt_message(char *topic, char *payload, AsyncMqttClientMessageProperties properties, size_t length, size_t index, size_t total) {
+void _mqtt_message(char* topic, byte* payload, unsigned int length) {
   log_d("mqtt message: %s -> %s", topic, payload);
   for (auto callback : _mqtt_message_callbacks) callback(topic, payload, length);
 }
@@ -90,20 +99,23 @@ bool mqtt_pmuctl_event_cb( EventBits_t event, void *arg ) {
 }
 
 void mqtt_loop( lv_task_t * task ) {
-  if (!mqtt_setup || !mqtt_run) return;
+  if (!mqtt_setup) return;
 
-  if (mqtt_get_event( MQTT_CONNECT )) {
-    mqtt_set_event( MQTT_CONNECTED );
-    mqtt_clear_event( MQTT_CONNECT );
-    mqtt_send_event_cb( MQTT_CONNECTED, (void *)NULL );
+  _mqtt_connection();
+  mqtt_client.loop();
+
+  if (mqtt_run && mqtt_get_event( MQTTCTL_CONNECT )) {
+    mqtt_set_event( MQTTCTL_CONNECTED );
+    mqtt_clear_event( MQTTCTL_CONNECT );
+    mqtt_send_event_cb( MQTTCTL_CONNECTED, (void *)NULL );
   }
-  if (mqtt_get_event( MQTT_DISCONNECT )) {
-    mqtt_set_event( MQTT_DISCONNECTED );
-    mqtt_clear_event( MQTT_DISCONNECT );
-    mqtt_send_event_cb( MQTT_DISCONNECTED, (void *)NULL );
+  if (mqtt_run && mqtt_get_event( MQTTCTL_DISCONNECT )) {
+    mqtt_set_event( MQTTCTL_DISCONNECTED );
+    mqtt_clear_event( MQTTCTL_DISCONNECT );
+    mqtt_send_event_cb( MQTTCTL_DISCONNECTED, (void *)NULL );
   }
 
-  if (mqtt_needs_publish) {
+  if (mqtt_run && mqtt_connected && mqtt_needs_publish) {
     mqtt_needs_publish = false;
 
     mqtt_publish_battery();
@@ -121,7 +133,7 @@ void mqtt_loop( lv_task_t * task ) {
 
 void mqtt_init( void ) {
   mqtt_status = xEventGroupCreate();
-  mqtt_set_event( MQTT_OFF );
+  mqtt_set_event( MQTTCTL_OFF );
   _mqtt_main_task = lv_task_create( mqtt_loop, 250, LV_TASK_PRIO_MID, NULL );
 }
 
@@ -130,13 +142,7 @@ void mqtt_start() {
   mqtt_run = true;
 
   if ( !mqtt_client.connected() ) {
-    {
-      char topic[64];
-      snprintf(topic, sizeof(topic), "%s/state", clientId);
-      mqtt_client.setWill(topic, 1, true, "offline");
-    }
-
-    mqtt_client.connect();
+    mqtt_client.connect( clientId );
   }
 }
 
@@ -147,23 +153,14 @@ void mqtt_start( const char *id, bool ssl, const char *server, int32_t port, con
   if ( !mqtt_client.connected() ) {
     log_i("use mqtt server:port as %s: %s:%d", id, server, port );
 
-    {
-      char topic[64];
-      snprintf(topic, sizeof(topic), "%s/state", clientId);
-      mqtt_client.setWill(topic, 1, true, "offline");
-    }
+    if (!mqtt_setup) mqtt_client.setCallback(_mqtt_message);
 
-    if (!mqtt_setup) mqtt_client.onConnect(_mqtt_connected);
-    if (!mqtt_setup) mqtt_client.onDisconnect(_mqtt_disconnected);
-    if (!mqtt_setup) mqtt_client.onSubscribe(_mqtt_subscribe);
-    if (!mqtt_setup) mqtt_client.onUnsubscribe(_mqtt_unsubscribe);
-    if (!mqtt_setup) mqtt_client.onMessage(_mqtt_message);
-
+    char topic[64];
     strlcpy( clientId, id, strlen( id ) + 1 );
-    mqtt_client.setClientId( id );
+    snprintf(topic, sizeof(topic), "%s/state", clientId);
+    
     mqtt_client.setServer( server, port );
-    mqtt_client.setCredentials( user, pass );
-    mqtt_client.connect();
+    mqtt_client.connect( clientId, user, pass, topic, 1, true, "offline" );
 
     if (!mqtt_setup) pmu_register_cb( PMUCTL_STATUS, mqtt_pmuctl_event_cb, "mqtt pmu");
   }
@@ -178,11 +175,11 @@ void mqtt_stop( void ) {
   if ( mqtt_setup && mqtt_client.connected() ) {
     log_i("stopping mqtt");
 
-    mqtt_set_event( MQTT_DISCONNECT );
-    mqtt_clear_event( MQTT_CONNECT | MQTT_OFF );
-    mqtt_send_event_cb( MQTT_DISCONNECT, (void *)0 );
+    mqtt_set_event( MQTTCTL_DISCONNECT );
+    mqtt_clear_event( MQTTCTL_CONNECT | MQTTCTL_OFF );
+    mqtt_send_event_cb( MQTTCTL_DISCONNECT, (void *)0 );
     
-    mqtt_client.disconnect(true);
+    mqtt_client.disconnect();
   }
 }
 
@@ -203,7 +200,7 @@ void mqtt_publish(const char* topic, bool retain, const char* payload) {
 void mqtt_publish_state() {
   char topic[64];
   snprintf(topic, sizeof(topic), "%s/state", clientId);
-  mqtt_client.publish(topic, 1, true, "online");
+  mqtt_client.publish(topic, "online", true);
 }
 
 void mqtt_publish_battery() {
@@ -215,7 +212,7 @@ void mqtt_publish_battery() {
     char payload[5];
     snprintf(payload, sizeof(payload), "%d", voltage);
 
-    mqtt_client.publish(topic, 0, true, payload);
+    mqtt_client.publish(topic, payload, true);
   }
 }
 
@@ -226,7 +223,7 @@ void mqtt_publish_version() {
   char payload[11];
   snprintf(payload, sizeof(payload), "%s", __FIRMWARE__);
 
-  mqtt_client.publish(topic, 0, true, payload);
+  mqtt_client.publish(topic, payload, true);
 }
 
 void mqtt_publish_ambient_temperature() {
@@ -238,7 +235,7 @@ void mqtt_publish_ambient_temperature() {
   char payload[6];
   snprintf(payload, sizeof(payload), "%.2f", ttgo->bma->temperature());
 
-  mqtt_client.publish(topic, 0, false, payload);
+  mqtt_client.publish(topic, payload, true);
 }
 
 void mqtt_publish_power_temperature() {
@@ -250,7 +247,7 @@ void mqtt_publish_power_temperature() {
   char payload[6];
   snprintf(payload, sizeof(payload), "%.2f", ttgo->power->getTemp());
 
-  mqtt_client.publish(topic, 0, false, payload);
+  mqtt_client.publish(topic, payload, true);
 }
 
 void mqtt_publish_heap() {
@@ -260,7 +257,7 @@ void mqtt_publish_heap() {
   char payload[22];
   snprintf(payload, sizeof(payload), "%d/%d", ESP.getFreeHeap(), ESP.getHeapSize());
 
-  mqtt_client.publish(topic, 0, false, payload);
+  mqtt_client.publish(topic, payload, true);
 }
 
 void mqtt_publish_psram() {
@@ -270,7 +267,7 @@ void mqtt_publish_psram() {
   char payload[22];
   snprintf(payload, sizeof(payload), "%d/%d", ESP.getFreePsram(), ESP.getPsramSize());
 
-  mqtt_client.publish(topic, 0, false, payload);
+  mqtt_client.publish(topic, payload, true);
 }
 
 void mqtt_publish_sketch() {
@@ -280,7 +277,7 @@ void mqtt_publish_sketch() {
   char payload[22];
   snprintf(payload, sizeof(payload), "%d/%d", ESP.getFreeSketchSpace(), ESP.getSketchSize());
 
-  mqtt_client.publish(topic, 0, false, payload);
+  mqtt_client.publish(topic, payload, true);
 }
 
 bool mqtt_get_connected() {

--- a/src/utils/mqtt/mqtt.h
+++ b/src/utils/mqtt/mqtt.h
@@ -22,17 +22,17 @@
 #ifndef _MQTT_H
     #define _MQTT_H
     
-    #include <AsyncMqttClient.h>
+    #include <PubSubClient.h>
     #include "hardware/callback.h"
     #include "stdint.h"
 
-    typedef std::function<void(char* topic, char* payload, size_t len)> MqttMessageCallback;
+    typedef std::function<void(char* topic, byte* payload, size_t len)> MqttMessageCallback;
     enum mqtt_event_t {
-        MQTT_OFF                    = _BV(0),
-        MQTT_CONNECT                = _BV(1),
-        MQTT_CONNECTED              = _BV(2),
-        MQTT_DISCONNECT             = _BV(3),
-        MQTT_DISCONNECTED           = _BV(4)
+        MQTTCTL_OFF                    = _BV(0),
+        MQTTCTL_CONNECT                = _BV(1),
+        MQTTCTL_CONNECTED              = _BV(2),
+        MQTTCTL_DISCONNECT             = _BV(3),
+        MQTTCTL_DISCONNECTED           = _BV(4)
     };
 
     /**

--- a/src/utils/mqtt/mqtt.h
+++ b/src/utils/mqtt/mqtt.h
@@ -30,9 +30,7 @@
     enum mqtt_event_t {
         MQTTCTL_OFF                    = _BV(0),
         MQTTCTL_CONNECT                = _BV(1),
-        MQTTCTL_CONNECTED              = _BV(2),
-        MQTTCTL_DISCONNECT             = _BV(3),
-        MQTTCTL_DISCONNECTED           = _BV(4)
+        MQTTCTL_DISCONNECT             = _BV(2)
     };
 
     /**


### PR DESCRIPTION
To lower the memory footprint, I replaced the AsyncMqttClient, that I introduced myself, with the PubSubClient, that was originally used in the powermeter app. Besides that, it makes not much of a difference in handling, so it was a no brainer.